### PR TITLE
Speed up mesh welding

### DIFF
--- a/Assets/Scripts/Manager.cs
+++ b/Assets/Scripts/Manager.cs
@@ -396,6 +396,9 @@ public class Manager : MonoBehaviour
 		{
 			if (weldModel)
 			{
+				Debug.Log("Welding meshes...");
+				DateTime start = DateTime.Now;
+
 				MeshWelder meshWelder = new MeshWelder();
 				foreach (CustomMesh customMesh in meshes)
 				{
@@ -407,6 +410,8 @@ public class Manager : MonoBehaviour
 					meshWelder.customMesh = customMesh;
 					meshWelder.Weld(true);
 				}
+
+				Debug.Log(string.Format("Welding completed in {0} seconds", (DateTime.Now - start).TotalSeconds));
 			}
 			
 			if (exportModel)

--- a/Assets/Scripts/MeshWelder.cs
+++ b/Assets/Scripts/MeshWelder.cs
@@ -1,12 +1,13 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
 /*
-	Originally created by Bunny83, modified to better fit the needs of this project + speed improvements
-	Could still probably be made to run faster...
-	http://answers.unity3d.com/questions/1382854/welding-vertices-at-runtime.html
-	https://www.dropbox.com/s/u0wfq42441pkoat/MeshWelder.cs?dl=0
+    Originally created by Bunny83, modified to better fit the needs of this project + speed improvements
+    Could still probably be made to run faster...
+    http://answers.unity3d.com/questions/1382854/welding-vertices-at-runtime.html
+    https://www.dropbox.com/s/u0wfq42441pkoat/MeshWelder.cs?dl=0
 */
 
 namespace B83.MeshHelper
@@ -17,62 +18,48 @@ namespace B83.MeshHelper
         Normal = 0x0002,
         UV1 = 0x0010,
     }
-	
+
     public class Vertex
     {
         public Vector3 pos;
         public Vector3 normal;
         public Vector2 uv1;
+
         public Vertex(Vector3 aPos)
         {
             pos = aPos;
         }
+
+        public override bool Equals(object obj)
+        {
+            Vertex other = obj as Vertex;
+            if (other != null)
+            {
+                return other.pos.Equals(pos) && other.normal.Equals(normal) && other.uv1.Equals(uv1);
+            }
+            return false;
+        }
+
+        public override int GetHashCode() // This can be improved
+        {
+            return pos.GetHashCode() ^ (normal.GetHashCode() << 2) ^ (uv1.GetHashCode() >> 2);
+        }
     }
-	
+
     public class MeshWelder
     {
-	
         Vertex[] vertices;
-        List<Vertex> newVerts;
+        Dictionary<Vertex, List<int>> newVerts;
         int[] map;
-		
+
         EVertexAttribute m_Attributes;
         public CustomMesh customMesh;
-		
+
         private bool HasAttr(EVertexAttribute aAttr)
         {
             return (m_Attributes & aAttr) != 0;
         }
-		
-        private bool Compare(Vertex v1, Vertex v2)
-        {
-			// Saved y for last because there's likely to be tons of verts with the same y value but not as many with x and z
-			if (v1.pos.x != v2.pos.x) return false;
-			if (v1.pos.z != v2.pos.z) return false;
-			if (v1.pos.y != v2.pos.y) return false;
-			
-			if (v1.normal.x != v2.normal.x) return false;
-			if (v1.normal.y != v2.normal.y) return false;
-			if (v1.normal.z != v2.normal.z) return false;
-			return true;
-        }
-		
-        private bool CompareWithUV(Vertex v1, Vertex v2)
-        {
-			// Saved y for last because there's likely to be tons of verts with the same y value but not as many with x and z
-			if (v1.pos.x != v2.pos.x) return false;
-			if (v1.pos.z != v2.pos.z) return false;
-			if (v1.pos.y != v2.pos.y) return false;
-			
-			if (v1.normal.x != v2.normal.x) return false;
-			if (v1.normal.y != v2.normal.y) return false;
-			if (v1.normal.z != v2.normal.z) return false;
-			
-			if (v1.uv1.x != v2.uv1.x) return false;
-			if (v1.uv1.y != v2.uv1.y) return false;
-            return true;
-        }
-		
+
         private void CreateVertexList()
         {
             var Positions = customMesh.vertices;
@@ -81,7 +68,7 @@ namespace B83.MeshHelper
             m_Attributes = EVertexAttribute.Position;
             if (Normals != null && Normals.Length > 0) m_Attributes |= EVertexAttribute.Normal;
             if (Uv1 != null && Uv1.Length > 0) m_Attributes |= EVertexAttribute.UV1;
-			
+
             vertices = new Vertex[Positions.Length];
             for (int i = 0; i < Positions.Length; i++)
             {
@@ -91,80 +78,63 @@ namespace B83.MeshHelper
                 vertices[i] = v;
             }
         }
+
         private void RemoveDuplicates()
         {
-            map = new int[vertices.Length];
-            newVerts = new List<Vertex>();
-            for (int i = 0; i < vertices.Length; i++)
+            newVerts = new Dictionary<Vertex, List<int>>(vertices.Length);
+            for(int i = 0; i < vertices.Length; i++)
             {
-                var v = vertices[i];
-                bool dup = false;
-                for (int i2 = 0; i2 < newVerts.Count; i2++)
+                Vertex v = vertices[i];
+                List<int> originals;
+                if (newVerts.TryGetValue(v, out originals))
                 {
-                    if (Compare(v, newVerts[i2]))
-                    {
-                        map[i] = i2;
-                        dup = true;
-                        break;
-                    }
+                    originals.Add(i);
                 }
-                if (!dup)
+                else
                 {
-                    map[i] = newVerts.Count;
-                    newVerts.Add(v);
+                    newVerts.Add(v, new List<int> {i});
                 }
             }
         }
-        private void RemoveDuplicatesWithUV()
-        {
-            map = new int[vertices.Length];
-            newVerts = new List<Vertex>();
-            for (int i = 0; i < vertices.Length; i++)
-            {
-                var v = vertices[i];
-                bool dup = false;
-                for (int i2 = 0; i2 < newVerts.Count; i2++)
-                {
-                    if (CompareWithUV(v, newVerts[i2]))
-                    {
-                        map[i] = i2;
-                        dup = true;
-                        break;
-                    }
-                }
-                if (!dup)
-                {
-                    map[i] = newVerts.Count;
-                    newVerts.Add(v);
-                }
-            }
-        }
+
         private void AssignNewVertexArrays()
         {
-            customMesh.vertices = newVerts.Select(v => v.pos).ToArray();
-            customMesh.normals = newVerts.Select(v => v.normal).ToArray();
+            map = new int[vertices.Length];
+            customMesh.vertices = new Vector3[newVerts.Count];
+            customMesh.normals = new Vector3[newVerts.Count];
             if (HasAttr(EVertexAttribute.UV1))
-                customMesh.uv = newVerts.Select(v => v.uv1).ToArray();
+                customMesh.uv = new Vector2[newVerts.Count];
+            int i = 0;
+            foreach (KeyValuePair<Vertex, List<int>> kvp in newVerts)
+            {
+                foreach (int index in kvp.Value)
+                {
+                    map[index] = i;
+                }
+                customMesh.vertices[i] = kvp.Key.pos;
+                customMesh.normals[i] = kvp.Key.normal;
+                if (HasAttr(EVertexAttribute.UV1))
+                    customMesh.uv[i] = kvp.Key.uv1;
+                i++;
+            }
         }
-		
+
         private void RemapTriangles()
         {
-            var tris = customMesh.triangles;
+            int[] tris = customMesh.triangles;
             for (int i = 0; i < tris.Length; i++)
             {
                 tris[i] = map[tris[i]];
             }
             customMesh.triangles = tris;
         }
+
         public void Weld(bool hasUV)
         {
             CreateVertexList();
-			if (hasUV)
-				RemoveDuplicatesWithUV();
-			else
-				RemoveDuplicates();
-            RemapTriangles();
+            RemoveDuplicates();
             AssignNewVertexArrays();
+            RemapTriangles();
         }
     }
 }


### PR DESCRIPTION
I've changed the mesh welding code to make use of a dictionary to check for duplicates, instead of the nested loop. This will theoretically run in O(n) instead of O(n^2).

I tested this on a model with 1,069,653 verts:
With the old code, it got reduced to 367,213 verts in 105.26 seconds,
With my new code, it got reduced to 367,230 verts in 0.35 seconds.
As you can see, it is significantly faster.

I'm not sure why it deleted 17 vertices less. At first I thought it was because the hashcode function I used was not good enough, but I don't think that's the case.