### PR TITLE
Fix MeshWelder's Vertex.GetHashCode

### DIFF
--- a/Assets/Scripts/MeshWelder.cs
+++ b/Assets/Scripts/MeshWelder.cs
@@ -40,9 +40,18 @@ namespace B83.MeshHelper
             return false;
         }
 
-        public override int GetHashCode() // This can be improved
+        public override int GetHashCode()
         {
-            return pos.GetHashCode() ^ (normal.GetHashCode() << 2) ^ (uv1.GetHashCode() >> 2);
+            unchecked
+            {
+                int hashCode = pos.x.GetHashCode();
+                hashCode = (hashCode * 397) ^ pos.y.GetHashCode();
+                hashCode = (hashCode * 397) ^ pos.z.GetHashCode();
+                hashCode = (hashCode * 397) ^ normal.x.GetHashCode();
+                hashCode = (hashCode * 397) ^ normal.z.GetHashCode();
+                hashCode = (hashCode * 397) ^ normal.y.GetHashCode();
+                return hashCode;
+            }
         }
     }
 


### PR DESCRIPTION
I've let resharper generate a new GetHashCode without using Unity's Vector3.GetHashCode, and it looks like it removes the same amount of vertices as the old code now.
I've only tested this with one model, so you might want to do some testing yourself, but I think it's ok now.

I'm still not quite sure why the first code didn't work though, the only reason I can think of is that somehow sometimes when two Vector3 objects are equal, they don't generate the same hashcode, but I don't know how that's possible.